### PR TITLE
add error flash message in order system

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -37,15 +37,20 @@ class Public::OrdersController < ApplicationController
         @selected_address = selected.address
         @selected_name = selected.name
       else
-        redirect_to new_order_path
+        @registered_addresses = Address.where(customer_id: current_customer.id)
+        render :new
       end
     when 2
-      unless params[:order][:new_postal_code] == "" && params[:order][:new_address] == "" && params[:order][:new_name] == ""
+      if params[:order][:postal_code].blank? || params[:order][:address].blank? || params[:order][:name].blank?
+        flash[:error] = "入力項目を全て入力してください。"
+        redirect_to new_order_path
+      elsif params[:order][:postal_code] !~ /^\d+$/ || params[:order][:postal_code].length != 7
+        flash[:error] = "郵便番号は7文字の半角数字で入力してください。"
+        redirect_to new_order_path
+      else
         @selected_postal_code = params[:order][:postal_code]
         @selected_address =  params[:order][:address]
         @selected_name = params[:order][:name]
-      else
-        redirect_to new_order_path
       end
     end
   end
@@ -71,7 +76,7 @@ class Public::OrdersController < ApplicationController
       end
       redirect_to thanks_order_path
     else
-      @order = Order.new
+      @registered_addresses = Address.where(customer_id: current_customer.id)
       render :new
     end
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,9 +1,18 @@
 class Order < ApplicationRecord
   belongs_to :customer
   has_many :order_details, dependent: :destroy
-  
+
   has_many :order_details
   has_many :items, through: :order_details
+
+  with_options presence: true do
+    validates :payment_method
+    validates :address
+    validates :name
+  end
+
+  validates :postal_code, length: { is: 7 }, numericality: { only_integer: true }
+
 
   enum status: {
     "入金待ち":0,

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -6,6 +6,7 @@
 
 
 <%= form_for @order, url: "/orders/confirm", method: :post do |f| %>
+<%= render "public/shared/error_messages", resource: @order %>
 
   <div class="row">
     <div class="col-lg-3">
@@ -67,6 +68,16 @@
       <%= f.label :shipping_address, "新しいお届け先" %>
     </div>
   </div>
+
+  <% flash.each do |error, value| %>
+    <div class="row mt-3">
+      <div class="col-lg-8 offset-lg-4 mb-2">
+        <div class="flash <%= error %>" style="color: #b57">
+          <%= value %>
+        </div>
+      </div>
+    </div>
+  <% end %>
 
   <!-- 郵便番号 -->
   <div class="row">

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -9,7 +9,7 @@
 　</div>
 
 　<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-　<%= render "public/shared/error_messages", resource: resource%>
+　<%= render "public/shared/error_messages", resource: resource %>
     <div class="row mb-3">
       <div class="col-lg-2 offset-lg-3">
         <%= f.label "メールアドレス" %>


### PR DESCRIPTION
## 注文フォームのエラー表示を追加しました。

新しい配送先を指定するフォームが空欄だった場合・郵便番号が半角数字の7文字でなかった場合に、newページへリダイレクトし、errorメッセージを表示するようにしました。